### PR TITLE
Add support for Guix manifest files

### DIFF
--- a/buffer-env.el
+++ b/buffer-env.el
@@ -69,6 +69,7 @@ This variable is obsolete.  Use `buffer-env-commands' instead."
 
 (defcustom buffer-env-commands
   '((".env" . "set -a && >&2 . \"$0\" && env -0")
+    ("manifest.scm" . "guix shell -m \"$0\" -- env -0")
     ("guix.scm" . ">&2 guix shell -D -f \"$0\" -- env -0")
     ("*" . ">&2 . \"$0\" && env -0"))
   "Alist of commands used to produce environment variables.


### PR DESCRIPTION
Next to the `-f` flag, `guix shell` can be initialized with a "manifest".  The advantage here is that instead of writing a script that evaluates to the package objects one needs, you can have it automatically generated (taking the example from the manual):

```
guix shell --export-manifest -D guile git emacs emacs-geiser emacs-geiser-guile > manifest.scm
```

By default `guix shell` also checks for `manifest.scm` and `guix.scm` in that order, so it makes sense to support both.