### PR TITLE
Add a minimal .dir-locals.el file

### DIFF
--- a/buffer-env.el
+++ b/buffer-env.el
@@ -243,3 +243,8 @@ When called interactively, ask for a FILE."
 
 (provide 'buffer-env)
 ;;; buffer-env.el ends here
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; show-trailing-whitespace: t
+;; End:


### PR DESCRIPTION
As mentioned in https://github.com/astoff/buffer-env/pull/5#discussion_r865083318, this would avoid whitespace issues caused by future (or current) contributors.